### PR TITLE
Fix a couple of Python 3.13 and Windows bugs

### DIFF
--- a/chert/core.py
+++ b/chert/core.py
@@ -6,6 +6,7 @@ import re
 import os
 import importlib.util
 import json
+import shutil
 import time
 import string
 import itertools
@@ -1071,11 +1072,10 @@ class Site(object):
             else:
                 message = None
                 if os.name == "nt":
-                    if os.path.exists(uploads_link_path) or os.path.islink(uploads_link_path):
-                        os.unlink(uploads_link_path)
-                    command = f'mklink /D "{uploads_link_path}" "{self.uploads_path}"'
-                    subprocess.run(command, shell=True, check=True)
-                    message = "Created symlink using mklink on Windows"
+                    if os.path.exists(uploads_link_path):
+                        shutil.rmtree(uploads_link_path)
+                    shutil.copytree(self.uploads_path, uploads_link_path)
+                    message = 'refreshed existing uploads files'
                 else:
                     if os.path.islink(uploads_link_path):
                         os.unlink(uploads_link_path)

--- a/chert/core.py
+++ b/chert/core.py
@@ -1073,12 +1073,9 @@ class Site(object):
                 if os.name == "nt":
                     if os.path.exists(uploads_link_path) or os.path.islink(uploads_link_path):
                         os.unlink(uploads_link_path)
-                    try:
-                        command = f'mklink /D "{uploads_link_path}" "{self.uploads_path}"'
-                        subprocess.run(command, shell=True, check=True)
-                        message = "Created symlink using mklink on Windows"
-                    except subprocess.CalledProcessError as e:
-                        message = f"Failed to create symlink: {e}"
+                    command = f'mklink /D "{uploads_link_path}" "{self.uploads_path}"'
+                    subprocess.run(command, shell=True, check=True)
+                    message = "Created symlink using mklink on Windows"
                 else:
                     if os.path.islink(uploads_link_path):
                         os.unlink(uploads_link_path)

--- a/chert/scaffold/chert.yaml
+++ b/chert/scaffold/chert.yaml
@@ -21,7 +21,7 @@ theme:
   name: sedimental
 
 dev:
-  server_host: 0.0.0.0
+  server_host: 127.0.0.1
   server_port: 8080
   base_url: /
   autorefresh: 0  # set to a positive integer to cause the default theme to autorefresh every few seconds


### PR DESCRIPTION
- The `imp` library was [removed in Python 3.12](https://docs.python.org/3/library/imp.html), this PR replaces it with `importlib`.
- `os.symlink` doesn't seem to work on Windows. I added a Windows-specific section that calls the system command `mklink /D ...`.
- The `pipes` library was [removed in Python 3.13](https://docs.python.org/3/library/pipes.html), this PR replaces it with `shlex`.